### PR TITLE
[add] info about rosidl_default_generators in p.66

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@
 | p.2  下から4行目|カレル・チャペット　　　 　 　　      |カレル・チャペック    　           | 
 | p.30 表2.1 トピックの行|データに伝送経路　　 　　      |データの伝送経路　　　　           | 
 | p.36 上から3行目|次節からHappy Mini　　　　 　　      |4.3.3節からHappy Mini　           | 
+| p.66 プログラムリスト 2.16 2行目|rosidl\_default\_generators | rosidl\_interface\_packages |


### PR DESCRIPTION
本文に誤植と思われる箇所を見つけました。
GitHubサポートサイトではこちらの修正通りの記述となっておりました。
確認のほど、よろしくお願いいたします。